### PR TITLE
Updating speak interface to check for two arguments, as well as build…

### DIFF
--- a/saybot.py
+++ b/saybot.py
@@ -7,4 +7,7 @@ class SayBot(BotPlugin):
     def say(self, mess, args):
         """A command that lets you tell the bot what to say on a channel"""
 
-        self.send(args[0], args[1], message_type="groupchat")
+        if len(args) < 2:
+          yield "I don't understand what you meant."
+        else:
+          self.send(self.build_identifier(args[0]), args[1])


### PR DESCRIPTION
… the backend identifier for speaking.

This supports the current errbot interface for using send (e.g. the need to call `build_identifier` to get the correct argument for the first argument to the `send` command.)
