### PR TITLE
When message contains colon, send whole message

### DIFF
--- a/saybot.py
+++ b/saybot.py
@@ -10,4 +10,4 @@ class SayBot(BotPlugin):
         if len(args) < 2:
           yield "I don't understand what you meant."
         else:
-          self.send(self.build_identifier(args[0]), ' '.join(args[1:]))
+          self.send(self.build_identifier(args[0]), ':'.join(args[1:]))

--- a/saybot.py
+++ b/saybot.py
@@ -10,4 +10,4 @@ class SayBot(BotPlugin):
         if len(args) < 2:
           yield "I don't understand what you meant."
         else:
-          self.send(self.build_identifier(args[0]), args[1])
+          self.send(self.build_identifier(args[0]), ' '.join(args[1:]))


### PR DESCRIPTION
Previously, if the message contained a ":", which is defined as the argument split character, only the first part of the message would be sent.

Example:
```
!say someroom: this is a message: with a colon
```
Gives:
```
this is a message
```

With this fix, it rejoins the remaining arguments as the message to be sent.